### PR TITLE
loosen activesupport version

### DIFF
--- a/volcanic-imageman.gemspec
+++ b/volcanic-imageman.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.glob 'lib/**/*.rb'
   spec.require_paths = %w(lib)
 
-  spec.add_dependency 'activesupport', '~> 6.0.5.1'
+  spec.add_dependency 'activesupport', '~> 6.0.4'
   spec.add_dependency 'faraday', '~> 1.0'
   spec.add_dependency 'faraday_middleware', '~> 1.0'
   spec.add_dependency 'marcel', '~> 1.0.0'


### PR DESCRIPTION
loosen activesupport version in the gemspec to ensure backwards compatability while running version bumps for rails on other projects.